### PR TITLE
Fix telegram notifier attribute error

### DIFF
--- a/telegram_notifier.py
+++ b/telegram_notifier.py
@@ -223,13 +223,13 @@ class TelegramNotifier:
             '/5': lambda chat_id, args: self._cmd_today(chat_id, []),
             '/6': lambda chat_id, args: self._cmd_week(chat_id, []),
             '/7': lambda chat_id, args: self._cmd_bigscan(chat_id, []),
-            '/8': lambda chat_id, args: self._cmd_config(chat_id, []),
+            '/8': lambda chat_id, args: self._cmd_config_menu(chat_id, []),
             '/9': lambda chat_id, args: self._cmd_help(chat_id, []),
             '/0': lambda chat_id, args: self._cmd_about(chat_id, []),
             
             # Raccourcis alphabétiques
             '/a': self._cmd_about,
-            '/c': self._cmd_config,
+            '/c': self._cmd_config_menu,
             '/d': self._cmd_departments_menu,
             '/e': self._cmd_export_menu,
             '/g': self._cmd_global_stats,


### PR DESCRIPTION
Fix `AttributeError` during deployment by correcting references to the `_cmd_config_menu` method.

---
<a href="https://cursor.com/background-agent?bcId=bc-980442a5-d89d-4c85-8597-60d749865b4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-980442a5-d89d-4c85-8597-60d749865b4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

